### PR TITLE
Change links to point to logicnow/master

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Read more in the [Wiki](https://github.com/logicnow/BlueSky/wiki)
 
 ## Docker Information
 
-Information regarding running BlueSky with docker can be found [in this README](https://github.com/sphen13/BlueSky/blob/docker/docker/README.md)
+Information regarding running BlueSky with docker can be found [in this README](https://github.com/logicnow/BlueSky/blob/master/docker/README.md)

--- a/docker/DOCKER_FULL_EXAMPLE.md
+++ b/docker/DOCKER_FULL_EXAMPLE.md
@@ -2,7 +2,7 @@
 
 This page shows an example setup consisting of several docker containers working together for easy deployment.
 
-The main documentation on how to use the bluesky container is in our main [README](../README.md)
+The main documentation on how to use the bluesky container is in our main [README](https://github.com/logicnow/BlueSky/blob/master/docker/README.md)
 
 ### Assumptions for this example
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ This is an attempt at getting BlueSky to run within docker.  This should allow i
 
 ### TL;DR
 
-We have a full example setup utilizing Caddy for automatic SSL cert generation [at this page](https://github.com/sphen13/BlueSky/blob/docker/docker/DOCKER_FULL_EXAMPLE.md).
+We have a full example setup utilizing Caddy for automatic SSL cert generation [at this page](https://github.com/logicnow/BlueSky/blob/master/docker/DOCKER_FULL_EXAMPLE.md).
 
 ### Environment variables
 


### PR DESCRIPTION
updates a few links within README's to point to proper location now.