### PR TITLE
Add Caddy ACME_AGREE ENV variable

### DIFF
--- a/docker/DOCKER_FULL_EXAMPLE.md
+++ b/docker/DOCKER_FULL_EXAMPLE.md
@@ -109,6 +109,7 @@ EOF
 docker run -d --name caddy \
   -p 80:80 \
   -p 443:443 \
+  -e ACME_AGREE=true \
   --link bluesky:bluesky \
   -v /var/docker/caddy/Caddyfile:/etc/Caddyfile \
   -v /var/docker/caddy:/root/.caddy \


### PR DESCRIPTION
Caddy now takes ACME_AGREE as a variable which may be needed when
starting the container.

https://github.com/abiosoft/caddy-docker#lets-encrypt-subscriber-agreeme
nt