### PR TITLE
Helper.sh fix

### DIFF
--- a/Client/helper.sh
+++ b/Client/helper.sh
@@ -61,7 +61,11 @@ if [[ -e /Library/Mac-MSP/BlueSky/helper.sh || ! -z $(pkgutil --pkgs | grep com.
   sleep 5
   #lets really make sure the old bluesky is gone...
   dscl . -delete /Users/mac-msp-bluesky
-  launchctl unload /Library/LaunchDaemons/com.mac-msp.bluesky.*.plist && rm -f /Library/LaunchDaemons/com.mac-msp.bluesky.*.plist
+  launchctl unload /Library/LaunchDaemons/com.mac-msp.bluesky* && rm -f /Library/LaunchDaemons/com.mac-msp.bluesky*
+  #lets clear out old package receipts so we dont cause a phantom loop
+  for i in $(pkgutil --pkgs | grep com.mac-msp.bluesky); do
+    pkgutil --forget "$i"
+  done
 fi
 
 if [ -e "$ourHome/.getHelp" ]; then

--- a/Client/helper.sh
+++ b/Client/helper.sh
@@ -74,7 +74,8 @@ if [ "$helpWithWhat" == "selfdestruct" ]; then
     killShells
     rm -rf "$ourHome"
     dscl . -delete /Users/bluesky
-    launchctl unload /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*.plist && rm -f /Library/LaunchDaemons/com.solarwindsmsp.bluesky.*.plist
+    launchctl unload /Library/LaunchDaemons/com.solarwindsmsp.bluesky* && rm -f /Library/LaunchDaemons/com.solarwindsmsp.bluesky*
+    pkgutil --forget com.solarwindsmsp.bluesky.pkg
     exit 0
 fi
 


### PR DESCRIPTION
With the help of @kginger, finally tracked down the bluesky 1.5 to 2.0 issue.  Really came down to pkg receipts not being forgotten.  It would then trigger bluesky to try to kill itself over an over even though bluesky 1.5 was already uninstalled.  I also cleaned up the launchd unload commands as it would have only pulled one of the 2.