### PR TITLE
mcrypt removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && \
     php-mysql \
     php \
     libapache2-mod-php \
-    php-mcrypt \
     php-mysql \
     inoticoming \
     supervisor \

--- a/Server/server-config.sh
+++ b/Server/server-config.sh
@@ -139,7 +139,7 @@ if [[ -z ${IN_DOCKER} ]]; then
   apt-get update
   sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $mysqlRootPass"
   sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $mysqlRootPass"
-  apt-get -y install apache2 fail2ban mysql-server php-mysql php libapache2-mod-php php-mcrypt php-mysql inoticoming swaks curl
+  apt-get -y install apache2 fail2ban mysql-server php-mysql php libapache2-mod-php php-mysql inoticoming swaks curl
 fi
 
 ## setup user accounts/folders


### PR DESCRIPTION
removing mcrypt requirement in php.  seems to work in my environment.

resolves #24 