### PR TITLE
Fix USE_HTTP syntax for non-docker instance

### DIFF
--- a/Server/server-config.sh
+++ b/Server/server-config.sh
@@ -26,6 +26,10 @@ webAdminPassword=""
 mysqlRootPass=""
 emailAlertAddress=""
 # --------- DO NOT EDIT BELOW ------------------------------------------------------
+if [[ -z ${USE_HTTP} ]]; then
+  USE_HTTP=0
+fi
+
 apacheConf="default-ssl"
 if [[ ${IN_DOCKER} ]]; then
   serverFQDN=$SERVERFQDN


### PR DESCRIPTION
introduced a bug for non-docker users in the past.  this should fix. please check my logic. @bestmacs 