### PR TITLE
Tunnel issues in High-C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.DS_Store
 Client/ssh

--- a/Client/bluesky.sh
+++ b/Client/bluesky.sh
@@ -130,7 +130,7 @@ function startMeUp {
   -c $prefCipher -m $msgAuth \
   $kexAlg \
   -o HostKeyAlgorithms=$keyAlg \
-  -nNT -R $sshport:localhost:$altPort -R $vncport:localhost:5900 -p 3122 \
+  -nNT -R $sshport:127.0.0.1:$altPort -R $vncport:127.0.0.1:5900 -p 3122 \
   $noRoam \
   -i "$ourHome/.ssh/bluesky_client" bluesky@$blueskyServer
   #echo "$!" > "$ourHome/autossh.pid"

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -60,11 +60,11 @@ if [ "$compRec" == "" ]; then
   #fetch unique ID
   myQry="SELECT MIN(t1.blueskyid + 1) AS nextID FROM computers t1 LEFT JOIN computers t2 ON t1.blueskyid + 1 = t2.blueskyid WHERE t2.blueskyid IS NULL"
   bluId=`$myCmd "$myQry"`
-  
+
   if [ "$bluId" == "NULL" ] || [ "$bluId" == "" ]; then
   	bluId=1
   fi
-  
+
   #safety check
   if [ ${bluId:-0} -gt 1949 ]; then
     echo "ERROR: maximum limit reached"
@@ -146,7 +146,7 @@ if [ $testExit -eq 0 ]; then
     snMismatch
   fi
 else #either down or defaults is messed up, try using PlistBuddy
-	testConn2=`ssh -p $sshPort -o StrictHostKeyChecking=no -l bluesky -i /usr/local/bin/BlueSky/Server/blueskyd localhost "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist"`
+	testConn2=`ssh -p $sshPort -o StrictHostKeyChecking=no -l bluesky -i /usr/local/bin/BlueSky/Server/blueskyd localhost "/usr/libexec/PlistBuddy -c 'Print serial' /var/bluesky/settings.plist" 2>&1`
 	testExit2=$?
 	if [ $testExit2 -eq 0 ]; then
 		if [ "$testConn2" == "$serialNum" ]; then
@@ -154,9 +154,15 @@ else #either down or defaults is messed up, try using PlistBuddy
 		else
 			snMismatch
 		fi
-	else #it's down
-		echo "Cannot connect."
-		myQry="update computers set status='ERROR: no tunnel established',datetime='$timeStamp' where serialnum='$serialNum'"
+	else #it's down - lets find out why
+    if [[ $testConn2 = *"ssh_exchange_identification"* ]]; then
+      # PKI exchange issue for bluesky user - lets return OK to keep tunnel up.
+      echo "OK"
+      myQry="update computers set status='ERROR: tunnel issue TO client',datetime='$timeStamp' where serialnum='$serialNum'"
+    else
+  		echo "Cannot connect."
+  		myQry="update computers set status='ERROR: tunnel issue FROM client',datetime='$timeStamp' where serialnum='$serialNum'"
+    fi
 		$myCmd "$myQry"
 	fi
 fi
@@ -186,7 +192,7 @@ SSH bluesky://com.solarwindsmsp.bluesky.admin?blueSkyID=$myPort&user=$myUser&act
 VNC bluesky://com.solarwindsmsp.bluesky.admin?blueSkyID=$myPort&user=$myUser&action=vnc
 SCP bluesky://com.solarwindsmsp.bluesky.admin?blueSkyID=$myPort&user=$myUser&action=scp"
 	fi
-	
+
 	myQry="update computers set notify=0 where serialnum='$serialNum'"
 	$myCmd "$myQry"
 fi

--- a/Server/processor.sh
+++ b/Server/processor.sh
@@ -155,14 +155,14 @@ else #either down or defaults is messed up, try using PlistBuddy
 			snMismatch
 		fi
 	else #it's down - lets find out why
-    if [[ $testConn2 = *"ssh_exchange_identification"* ]]; then
-      # PKI exchange issue for bluesky user - lets return OK to keep tunnel up.
-      echo "OK"
-      myQry="update computers set status='ERROR: tunnel issue TO client',datetime='$timeStamp' where serialnum='$serialNum'"
-    else
-  		echo "Cannot connect."
-  		myQry="update computers set status='ERROR: tunnel issue FROM client',datetime='$timeStamp' where serialnum='$serialNum'"
-    fi
+		if [[ $testConn2 = *"ssh_exchange_identification"* ]]; then
+			# PKI exchange issue for bluesky user - lets return OK to keep tunnel up.
+			echo "OK"
+			myQry="update computers set status='ERROR: tunnel issue TO client',datetime='$timeStamp' where serialnum='$serialNum'"
+		else
+			echo "Cannot connect."
+			myQry="update computers set status='ERROR: no tunnel established',datetime='$timeStamp' where serialnum='$serialNum'"
+		fi
 		$myCmd "$myQry"
 	fi
 fi


### PR DESCRIPTION
Deeper testing on why a connection cannot be made. If a tunnel is up but we cant get back to the client return:
> ERROR: tunnel issue TO client
Currently the tunnel will not be restarted with this result

Better yet - At least in my situation, The tunnel back to the client was erroring due to intermittent issues resolving localhost.  This changes the agent and specifies 127.0.0.1 in the ssh command instead.