### PR TITLE
Fixes bad permissions that prevent sshd from authenticating

### DIFF
--- a/Server/server-config.sh
+++ b/Server/server-config.sh
@@ -162,6 +162,8 @@ chown www-data /home/admin/newkeys
 chown www-data /home/bluesky/newkeys
 chown -R admin /home/admin/.ssh
 chown -R bluesky /home/bluesky/.ssh
+chmod -R go-rwx /home/admin/.ssh
+chmod -R go-rwx /home/bluesky/.ssh
 # sets auth.log so admin can read it
 touch /var/log/auth.log
 chgrp admin /var/log/auth.log


### PR DESCRIPTION
I found out the cause of my _ERROR: no tunnel established_ problems. It appears that the .ssh directories created for the admin and bluesky users on the server are too permissive:

    # ls -al /home/bluesky/.ssh/
    total 12
    drwxrwxrwx 2 bluesky root 4096 Sep  9 11:26 .
    drwxr-xr-x 4 root    root 4096 Sep  6 16:44 ..
    -rw-r--r-- 1 bluesky root  398 Sep  9 11:26 authorized_keys

`sshd` will refuse connections if these directories are not locked down.